### PR TITLE
Make ContextID public

### DIFF
--- a/surfman/src/context.rs
+++ b/surfman/src/context.rs
@@ -5,7 +5,7 @@ use crate::info::GLVersion;
 
 use std::sync::Mutex;
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct ContextID(pub u64);
 
 lazy_static! {

--- a/surfman/src/context.rs
+++ b/surfman/src/context.rs
@@ -1,5 +1,6 @@
 //! Declarations common to all platform contexts.
 
+use crate::Context;
 use crate::info::GLVersion;
 
 use std::sync::Mutex;
@@ -9,6 +10,12 @@ pub struct ContextID(pub u64);
 
 lazy_static! {
     pub static ref CREATE_CONTEXT_MUTEX: Mutex<ContextID> = Mutex::new(ContextID(0));
+}
+
+impl Context {
+    pub fn id(&self) -> ContextID {
+        self.id
+    }
 }
 
 bitflags! {

--- a/surfman/src/lib.rs
+++ b/surfman/src/lib.rs
@@ -26,7 +26,7 @@ pub mod error;
 pub use crate::error::{Error, WindowingApiError};
 
 mod context;
-pub use crate::context::{ContextAttributes, ContextAttributeFlags};
+pub use crate::context::{ContextAttributes, ContextAttributeFlags, ContextID};
 
 mod info;
 pub use crate::info::{GLApi, GLVersion};

--- a/surfman/src/surface.rs
+++ b/surfman/src/surface.rs
@@ -1,5 +1,7 @@
 //! Information related to hardware surfaces.
 
+use crate::ContextID;
+use crate::Surface;
 use std::fmt::{self, Display, Formatter};
 
 // The default framebuffer for a context.
@@ -18,5 +20,11 @@ pub struct SurfaceID(pub usize);
 impl Display for SurfaceID {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{:?}", *self)
+    }
+}
+
+impl Surface {
+    pub fn context_id(&self) -> ContextID {
+        self.context_id
     }
 }


### PR DESCRIPTION
Making context ID public makes it possible for users to find out if they have the "right" context ahead of time, rather than doing operations and hoping they don't throw exceptions.