### PR TITLE
Fix cross-compiling build.rs

### DIFF
--- a/surfman/build.rs
+++ b/surfman/build.rs
@@ -6,12 +6,14 @@ use std::fs::File;
 use std::path::PathBuf;
 
 fn main() {
-    let target = env::var("TARGET").unwrap();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let target_family = env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
     let dest = PathBuf::from(&env::var("OUT_DIR").unwrap());
 
-    if target.contains("android") ||
-            (target.contains("windows") && cfg!(feature = "sm-angle")) ||
-            cfg!(feature = "test_egl_in_linux") {
+    if (target_os == "android")
+        || ((target_os == "windows") && cfg!(feature = "sm-angle"))
+        || cfg!(feature = "test_egl_in_linux")
+    {
         let mut file = File::create(&dest.join("egl_bindings.rs")).unwrap();
         let registry = Registry::new(Api::Egl, (1, 5), Profile::Core, Fallbacks::All, [
             "EGL_KHR_gl_image",
@@ -23,15 +25,16 @@ fn main() {
         // On Windows when relying on %LIBS% to contain libEGL.lib, however,
         // we must explicitly use rustc-link-lib=libEGL or rustc will attempt
         // to link EGL.lib instead.
-        if target.contains("windows") {
+        if target_os == "windows" {
             println!("cargo:rustc-link-lib=libEGL");
         } else {
             println!("cargo:rustc-link-lib=EGL");
         }
     }
 
-    if cfg!(any(feature = "sm-x11",
-                all(unix, not(any(target_os = "macos", target_os = "android"))))) {
+    if cfg!(feature = "sm-x11")
+        || ((target_family == "unix") && (target_os != "macos") && (target_os != "android"))
+    {
         let mut file = File::create(&dest.join("glx_bindings.rs")).unwrap();
         Registry::new(Api::Glx, (1, 4), Profile::Core, Fallbacks::All, [
             "GLX_ARB_create_context",


### PR DESCRIPTION
TIL `cfg!(target_os = xxx)` in a x-compiling build.rs means the build machine's OS not the target OS :/