### PR TITLE
Avoid winit 0.19.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+
+members = [
+    "surfman",
+]

--- a/surfman/Cargo.toml
+++ b/surfman/Cargo.toml
@@ -41,7 +41,7 @@ version = "0.1"
 optional = true
 
 [dependencies.winit]
-version = "0.19"
+version = "<0.19.4" # 0.19.4 causes build errors https://github.com/rust-windowing/winit/pull/1105
 optional = true
 
 [dev-dependencies]


### PR DESCRIPTION
Winit 0.19.4 is broken, sigh. Together with #10 this should fix the build on travis.