### PR TITLE
Add hardware and software modules, and allow the unviersal module to be the default

### DIFF
--- a/surfman/Cargo.toml
+++ b/surfman/Cargo.toml
@@ -19,12 +19,14 @@ gl_generator = "0.11"
 default = ["sm-winit"]
 sm-angle = []
 sm-angle-builtin = ["mozangle"]
-sm-angle-default = ["sm-angle"]
 sm-osmesa = ["osmesa-sys"]
-sm-osmesa-default = ["sm-osmesa"]
-sm-no-wgl = ["sm-angle-default"]
+sm-no-wgl = ["sm-angle"]
 sm-winit = ["winit"]
 sm-x11 = ["x11"]
+sm-software = ["sm-osmesa"]
+sm-software-default = ["sm-software"]
+sm-universal = ["sm-software"]
+sm-universal-default = ["sm-universal"]
 
 [dependencies]
 bitflags = "1.1"

--- a/surfman/src/context.rs
+++ b/surfman/src/context.rs
@@ -12,7 +12,14 @@ lazy_static! {
     pub static ref CREATE_CONTEXT_MUTEX: Mutex<ContextID> = Mutex::new(ContextID(0));
 }
 
-impl Context {
+impl crate::platform::hardware::context::Context {
+    pub fn id(&self) -> ContextID {
+        self.id
+    }
+}
+
+#[cfg(feature = "sm-software")]
+impl crate::platform::software::context::Context {
     pub fn id(&self) -> ContextID {
         self.id
     }

--- a/surfman/src/platform/generic/mod.rs
+++ b/surfman/src/platform/generic/mod.rs
@@ -6,7 +6,5 @@ pub(crate) mod egl;
 #[cfg(feature = "sm-osmesa")]
 pub mod osmesa;
 
-#[cfg(all(feature = "sm-osmesa", not(all(target_os = "windows", feature = "sm-angle"))))]
+#[cfg(feature = "sm-universal")]
 pub mod universal;
-#[cfg(all(target_os = "windows", feature = "sm-angle"))]
-pub use crate::platform::windows::angle as universal;

--- a/surfman/src/platform/generic/universal/adapter.rs
+++ b/surfman/src/platform/generic/universal/adapter.rs
@@ -1,13 +1,13 @@
 //! An adapter abstraction that can choose between hardware and software rendering.
 
 use crate::Error;
-use crate::platform::default::adapter::Adapter as HWAdapter;
-use crate::platform::generic::osmesa::adapter::Adapter as OSMesaAdapter;
+use crate::platform::hardware::adapter::Adapter as HWAdapter;
+use crate::platform::software::adapter::Adapter as SWAdapter;
 
 #[derive(Clone, Debug)]
 pub enum Adapter {
     Hardware(HWAdapter),
-    Software(OSMesaAdapter),
+    Software(SWAdapter),
 }
 
 impl Adapter {
@@ -28,6 +28,6 @@ impl Adapter {
     /// Returns the "best" software adapter on this system.
     #[inline]
     pub fn software() -> Result<Adapter, Error> {
-        OSMesaAdapter::default().map(Adapter::Software)
+        SWAdapter::default().map(Adapter::Software)
     }
 }

--- a/surfman/src/platform/generic/universal/context.rs
+++ b/surfman/src/platform/generic/universal/context.rs
@@ -1,14 +1,14 @@
 //! A context abstraction that can switch between hardware and software rendering.
 
 use crate::gl::types::GLuint;
-use crate::platform::default::context::Context as HWContext;
-use crate::platform::default::context::ContextDescriptor as HWContextDescriptor;
-use crate::platform::default::surface::SurfaceType as HWSurfaceType;
-use crate::platform::default::device::Device as HWDevice;
-use crate::platform::generic::osmesa::context::Context as OSMesaContext;
-use crate::platform::generic::osmesa::context::ContextDescriptor as OSMesaContextDescriptor;
-use crate::platform::generic::osmesa::device::Device as OSMesaDevice;
-use crate::{ContextAttributes, Error, SurfaceID};
+use crate::platform::hardware::context::Context as HWContext;
+use crate::platform::hardware::context::ContextDescriptor as HWContextDescriptor;
+use crate::platform::hardware::surface::SurfaceType as HWSurfaceType;
+use crate::platform::hardware::device::Device as HWDevice;
+use crate::platform::software::context::Context as SWContext;
+use crate::platform::software::context::ContextDescriptor as SWContextDescriptor;
+use crate::platform::software::device::Device as SWDevice;
+use crate::{ContextAttributes, ContextID, Error, SurfaceID};
 use super::device::Device;
 use super::surface::Surface;
 use super::surface::SurfaceType;
@@ -18,13 +18,13 @@ use std::os::raw::c_void;
 
 pub enum Context {
     Hardware(HWContext),
-    Software(OSMesaContext),
+    Software(SWContext),
 }
 
 #[derive(Clone)]
 pub enum ContextDescriptor {
     Hardware(HWContextDescriptor),
-    Software(OSMesaContextDescriptor),
+    Software(SWContextDescriptor),
 }
 
 impl Device {
@@ -49,7 +49,7 @@ impl Device {
 
     /// Opens the device and context corresponding to the current software context.
     pub unsafe fn from_current_software_context() -> Result<(Device, Context), Error> {
-        OSMesaDevice::from_current_context().map(|(device, context)| {
+        SWDevice::from_current_context().map(|(device, context)| {
             (Device::Software(device), Context::Software(context))
         })
     }
@@ -201,6 +201,19 @@ impl Device {
                 device.get_proc_address(context, symbol_name)
             }
             _ => panic!("Incompatible context!"),
+        }
+    }
+}
+
+impl Context {
+    pub fn id(&self) -> ContextID {
+        match self {
+            &Context::Hardware(ref ctx) => {
+                ctx.id
+            }
+            &Context::Software(ref ctx) => {
+                ctx.id
+            }
         }
     }
 }

--- a/surfman/src/platform/generic/universal/device.rs
+++ b/surfman/src/platform/generic/universal/device.rs
@@ -1,13 +1,13 @@
 //! A device abstraction that can switch between hardware and software rendering.
 
 use crate::{Error, GLApi};
-use crate::platform::default::device::Device as HWDevice;
-use crate::platform::generic::osmesa::device::Device as OSMesaDevice;
+use crate::platform::hardware::device::Device as HWDevice;
+use crate::platform::software::device::Device as SWDevice;
 use super::adapter::Adapter;
 
 pub enum Device {
     Hardware(HWDevice),
-    Software(OSMesaDevice),
+    Software(SWDevice),
 }
 
 impl Device {
@@ -15,7 +15,7 @@ impl Device {
     pub fn new(adapter: &Adapter) -> Result<Device, Error> {
         match *adapter {
             Adapter::Hardware(ref adapter) => HWDevice::new(adapter).map(Device::Hardware),
-            Adapter::Software(ref adapter) => OSMesaDevice::new(adapter).map(Device::Software),
+            Adapter::Software(ref adapter) => SWDevice::new(adapter).map(Device::Software),
         }
     }
 

--- a/surfman/src/platform/generic/universal/surface.rs
+++ b/surfman/src/platform/generic/universal/surface.rs
@@ -1,9 +1,9 @@
 //! A surface abstraction that can switch between hardware and software rendering.
 
 use crate::gl::types::{GLenum, GLuint};
-use crate::platform::default::surface::{Surface as HWSurface, SurfaceTexture as HWSurfaceTexture, SurfaceType as HWSurfaceType};
-use crate::platform::generic::osmesa::surface::Surface as OSMesaSurface;
-use crate::platform::generic::osmesa::surface::SurfaceTexture as OSMesaSurfaceTexture;
+use crate::platform::hardware::surface::{Surface as HWSurface, SurfaceTexture as HWSurfaceTexture, SurfaceType as HWSurfaceType};
+use crate::platform::software::surface::Surface as SWSurface;
+use crate::platform::software::surface::SurfaceTexture as SWSurfaceTexture;
 use crate::{Error, SurfaceID};
 use super::context::Context;
 use super::device::Device;
@@ -16,12 +16,12 @@ pub use crate::platform::generic::osmesa::surface::NativeWidget;
 #[derive(Debug)]
 pub enum Surface {
     Hardware(HWSurface),
-    Software(OSMesaSurface),
+    Software(SWSurface),
 }
 
 pub enum SurfaceTexture {
     Hardware(HWSurfaceTexture),
-    Software(OSMesaSurfaceTexture),
+    Software(SWSurfaceTexture),
 }
 
 impl Device {

--- a/surfman/src/platform/mod.rs
+++ b/surfman/src/platform/mod.rs
@@ -1,29 +1,34 @@
 //! Platform-specific backends.
 
 pub mod generic;
-#[cfg(feature = "sm-osmesa-default")]
-pub use generic::osmesa as default;
+#[cfg(feature = "sm-software")]
+pub use generic::osmesa as software;
 
 #[cfg(target_os = "android")]
 pub mod android;
 #[cfg(target_os = "android")]
-pub use android as default;
+pub use android as hardware;
 
 #[cfg(target_os = "macos")]
 pub mod macos;
-#[cfg(all(target_os = "macos", not(any(feature = "sm-x11", feature = "sm-osmesa-default"))))]
-pub use macos as default;
+#[cfg(target_os = "macos")]
+pub use macos as hardware;
 
 #[cfg(unix)]
 pub mod unix;
-#[cfg(all(any(feature = "sm-x11", all(unix, not(any(target_os = "macos", target_os = "android")))),
-          not(feature = "sm-osmesa-default")))]
-pub use unix::x11 as default;
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "android")))]
+pub use unix::x11 as hardware;
 
 #[cfg(target_os = "windows")]
 pub mod windows;
-#[cfg(all(target_os = "windows", feature = "sm-angle-default"))]
-pub use windows::angle as default;
-#[cfg(all(target_os = "windows",
-          not(any(feature = "sm-osmesa-default", feature = "sm-angle-default"))))]
-pub use windows::wgl as default;
+#[cfg(all(target_os = "windows", feature = "sm-angle"))]
+pub use windows::angle as hardware;
+#[cfg(all(target_os = "windows", not(feature = "sm-angle")))]
+pub use windows::wgl as hardware;
+
+#[cfg(feature = "sm-software-default")]
+pub use software as default;
+#[cfg(feature = "sm-universal-default")]
+pub use generic::universal as default;
+#[cfg(all(not(feature = "sm-universal-default"), not(feature = "sm-software-default")))]
+pub use hardware as default;


### PR DESCRIPTION
Replaces the `*-default` features by `software-default` and `universal-default`.