### PR TITLE
Support creating surfaces from existing D3D textures

### DIFF
--- a/surfman/src/platform/windows/angle/adapter.rs
+++ b/surfman/src/platform/windows/angle/adapter.rs
@@ -6,7 +6,7 @@ use std::cell::{RefCell, RefMut};
 use std::os::raw::c_void;
 use std::ptr;
 use winapi::Interface;
-use winapi::shared::dxgi::{self, IDXGIAdapter, IDXGIAdapter1, IDXGIDevice, IDXGIFactory1};
+use winapi::shared::dxgi::{self, IDXGIAdapter, IDXGIFactory1};
 use winapi::shared::winerror;
 use winapi::um::d3dcommon::{D3D_DRIVER_TYPE, D3D_DRIVER_TYPE_HARDWARE, D3D_DRIVER_TYPE_UNKNOWN, D3D_DRIVER_TYPE_WARP};
 use wio::com::ComPtr;

--- a/surfman/src/platform/windows/angle/context.rs
+++ b/surfman/src/platform/windows/angle/context.rs
@@ -69,6 +69,7 @@ impl Device {
         let alpha_size   = if flags.contains(ContextAttributeFlags::ALPHA)   { 8  } else { 0 };
         let depth_size   = if flags.contains(ContextAttributeFlags::DEPTH)   { 24 } else { 0 };
         let stencil_size = if flags.contains(ContextAttributeFlags::STENCIL) { 8  } else { 0 };
+        let color_size = 8;
 
         unsafe {
             // Create config attributes.
@@ -76,9 +77,9 @@ impl Device {
                 egl::SURFACE_TYPE as EGLint,         egl::PBUFFER_BIT as EGLint,
                 egl::RENDERABLE_TYPE as EGLint,      egl::OPENGL_ES2_BIT as EGLint,
                 egl::BIND_TO_TEXTURE_RGBA as EGLint, 1 as EGLint,
-                egl::RED_SIZE as EGLint,             8,
-                egl::GREEN_SIZE as EGLint,           8,
-                egl::BLUE_SIZE as EGLint,            8,
+                egl::RED_SIZE as EGLint,             color_size,
+                egl::GREEN_SIZE as EGLint,           color_size,
+                egl::BLUE_SIZE as EGLint,            color_size,
                 egl::ALPHA_SIZE as EGLint,           alpha_size,
                 egl::DEPTH_SIZE as EGLint,           depth_size,
                 egl::STENCIL_SIZE as EGLint,         stencil_size,
@@ -86,20 +87,59 @@ impl Device {
                 0,                                   0,
             ];
 
-            // Pick a config.
-            let (mut config, mut config_count) = (ptr::null(), 0);
+            // Determine the number of available configs.
+            let mut config_count = 0;
             let result = egl::ChooseConfig(self.native_display.egl_display(),
                                            config_attributes.as_ptr(),
-                                           &mut config,
-                                           1,
+                                           ptr::null_mut(),
+                                           0,
                                            &mut config_count);
             if result == egl::FALSE {
                 let err = egl::GetError().to_windowing_api_error();
                 return Err(Error::PixelFormatSelectionFailed(err));
             }
-            if config_count == 0 || config.is_null() {
+            if config_count <= 0 {
                 return Err(Error::NoPixelFormatFound);
             }
+
+            // Pick a config.
+            let mut configs = vec![ptr::null(); config_count as usize];
+            let result = egl::ChooseConfig(self.native_display.egl_display(),
+                                           config_attributes.as_ptr(),
+                                           configs.as_mut_ptr(),
+                                           config_count,
+                                           &mut config_count);
+            assert_ne!(result, egl::FALSE);
+
+            let mut config = None;
+            for candidate in configs.into_iter() {
+                let attrs = [
+                    (egl::RED_SIZE, color_size),
+                    (egl::GREEN_SIZE, color_size),
+                    (egl::BLUE_SIZE, color_size),
+                    (egl::ALPHA_SIZE, alpha_size)
+                ];
+                let attrs_are_minimum_width = attrs.iter().all(|&(attr, size)| {
+                    if size == 0 {
+                        return true;
+                    }
+                    let component_size = get_config_attr(
+                        self.native_display.egl_display(),
+                        candidate,
+                        attr as EGLint,
+                    );
+                    component_size == size
+                });
+                if attrs_are_minimum_width {
+                    config = Some(candidate);
+                    break;
+                }
+            }
+
+            let config = match config {
+                Some(config) => config,
+                None => return Err(Error::NoPixelFormatFound),
+            };
 
             // Get the config ID and version.
             let egl_config_id = get_config_attr(self.native_display.egl_display(),

--- a/surfman/src/platform/windows/angle/context.rs
+++ b/surfman/src/platform/windows/angle/context.rs
@@ -5,23 +5,20 @@ use crate::egl::types::{EGLAttrib, EGLConfig, EGLContext, EGLDeviceEXT, EGLDispl
 use crate::egl::types::{EGLenum, EGLint};
 use crate::egl;
 use crate::gl::types::GLuint;
-use crate::gl::{self, Gl};
+use crate::gl::Gl;
 use crate::platform::generic::egl::error::ToWindowingApiError;
 use crate::surface::Framebuffer;
-use crate::{ContextAttributeFlags, ContextAttributes, Error, GLApi, GLVersion, SurfaceAccess};
+use crate::{ContextAttributeFlags, ContextAttributes, Error, GLVersion, SurfaceAccess};
 use crate::{SurfaceID, SurfaceType};
-use super::adapter::Adapter;
 use super::device::{Device, EGL_D3D11_DEVICE_ANGLE, EGL_EXTENSION_FUNCTIONS};
 use super::device::{EGL_NO_DEVICE_EXT, OwnedEGLDisplay};
-use super::surface::{NativeWidget, Surface, SurfaceTexture, Win32Objects};
+use super::surface::{NativeWidget, Surface, Win32Objects};
 
 use euclid::default::Size2D;
 use std::ffi::CString;
 use std::mem;
 use std::os::raw::{c_char, c_void};
 use std::ptr;
-use std::str::FromStr;
-use std::sync::Mutex;
 use std::thread;
 use winapi::shared::winerror::S_OK;
 use winapi::um::d3d11::ID3D11Device;
@@ -201,13 +198,12 @@ impl Device {
         // detect the "Microsoft Basic" string and switch to `D3D_DRIVER_TYPE_WARP` as appropriate.
         let device = Device {
             native_display: Box::new(OwnedEGLDisplay { egl_display }),
-            egl_device,
             d3d11_device,
             d3d_driver_type: D3D_DRIVER_TYPE_UNKNOWN,
         };
 
         // Create the config.
-        let mut context = Context {
+        let context = Context {
             native_context,
             id: *next_context_id,
             framebuffer: Framebuffer::External,
@@ -235,10 +231,10 @@ impl Device {
                 0, 0,
             ];
 
-            let mut egl_context = egl::CreateContext(self.native_display.egl_display(),
-                                                     egl_config,
-                                                     egl::NO_CONTEXT,
-                                                     egl_context_attributes.as_ptr());
+            let egl_context = egl::CreateContext(self.native_display.egl_display(),
+                                                 egl_config,
+                                                 egl::NO_CONTEXT,
+                                                 egl_context_attributes.as_ptr());
             if egl_context == egl::NO_CONTEXT {
                 let err = egl::GetError().to_windowing_api_error();
                 return Err(Error::ContextCreationFailed(err));
@@ -264,7 +260,7 @@ impl Device {
         }
 
         if let Some(surface) = self.release_surface(context) {
-            self.destroy_surface(context, surface);
+            self.destroy_surface(context, surface)?;
         }
 
         unsafe {
@@ -275,22 +271,20 @@ impl Device {
     }
 
     pub fn context_descriptor(&self, context: &Context) -> ContextDescriptor {
-        unsafe {
-            let egl_config_id = get_context_attr(self.native_display.egl_display(),
-                                                 context.native_context.egl_context(),
-                                                 egl::CONFIG_ID as EGLint);
-            let egl_context_client_version =
-                get_context_attr(self.native_display.egl_display(),
-                                 context.native_context.egl_context(),
-                                 egl::CONTEXT_CLIENT_VERSION as EGLint);
-            ContextDescriptor { egl_config_id, egl_context_client_version }
-        }
+        let egl_config_id = get_context_attr(self.native_display.egl_display(),
+                                             context.native_context.egl_context(),
+                                             egl::CONFIG_ID as EGLint);
+        let egl_context_client_version =
+            get_context_attr(self.native_display.egl_display(),
+                             context.native_context.egl_context(),
+                             egl::CONTEXT_CLIENT_VERSION as EGLint);
+        ContextDescriptor { egl_config_id, egl_context_client_version }
     }
 
     pub fn make_context_current(&self, context: &Context) -> Result<(), Error> {
         unsafe {
-            let (egl_surface, size) = match context.framebuffer {
-                Framebuffer::Surface(ref surface) => (surface.egl_surface, surface.size),
+            let egl_surface = match context.framebuffer {
+                Framebuffer::Surface(ref surface) => surface.egl_surface,
                 Framebuffer::None | Framebuffer::External => {
                     return Err(Error::ExternalRenderTarget)
                 }
@@ -368,7 +362,7 @@ impl Device {
             // If the surface does not use a DXGI keyed mutex, then finish.
             // FIXME(pcwalton): Is this necessary and sufficient?
             if !new_surface.uses_keyed_mutex() {
-                let guard = self.temporarily_make_context_current(context)?;
+                let _guard = self.temporarily_make_context_current(context)?;
                 GL_FUNCTIONS.with(|gl| gl.Finish());
             }
 
@@ -385,7 +379,7 @@ impl Device {
     }
 
     #[inline]
-    pub fn context_surface_framebuffer_object(&self, context: &Context) -> Result<GLuint, Error> {
+    pub fn context_surface_framebuffer_object(&self, _context: &Context) -> Result<GLuint, Error> {
         Ok(0)
     }
 
@@ -404,24 +398,22 @@ impl Device {
         let egl_display = self.native_display.egl_display();
         let egl_config = self.context_descriptor_to_egl_config(context_descriptor);
 
-        unsafe {
-            let alpha_size = get_config_attr(egl_display, egl_config, egl::ALPHA_SIZE as EGLint);
-            let depth_size = get_config_attr(egl_display, egl_config, egl::DEPTH_SIZE as EGLint);
-            let stencil_size = get_config_attr(egl_display,
-                                               egl_config,
-                                               egl::STENCIL_SIZE as EGLint);
+        let alpha_size = get_config_attr(egl_display, egl_config, egl::ALPHA_SIZE as EGLint);
+        let depth_size = get_config_attr(egl_display, egl_config, egl::DEPTH_SIZE as EGLint);
+        let stencil_size = get_config_attr(egl_display,
+                                           egl_config,
+                                           egl::STENCIL_SIZE as EGLint);
 
-            // Convert to `surfman` context attribute flags.
-            let mut attribute_flags = ContextAttributeFlags::empty();
-            attribute_flags.set(ContextAttributeFlags::ALPHA, alpha_size != 0);
-            attribute_flags.set(ContextAttributeFlags::DEPTH, depth_size != 0);
-            attribute_flags.set(ContextAttributeFlags::STENCIL, stencil_size != 0);
+        // Convert to `surfman` context attribute flags.
+        let mut attribute_flags = ContextAttributeFlags::empty();
+        attribute_flags.set(ContextAttributeFlags::ALPHA, alpha_size != 0);
+        attribute_flags.set(ContextAttributeFlags::DEPTH, depth_size != 0);
+        attribute_flags.set(ContextAttributeFlags::STENCIL, stencil_size != 0);
 
-            // Create appropriate context attributes.
-            ContextAttributes {
-                flags: attribute_flags,
-                version: GLVersion::new(context_descriptor.egl_context_client_version as u8, 0),
-            }
+        // Create appropriate context attributes.
+        ContextAttributes {
+            flags: attribute_flags,
+            version: GLVersion::new(context_descriptor.egl_context_client_version as u8, 0),
         }
     }
 
@@ -539,7 +531,7 @@ impl NativeContext for UnsafeEGLContextRef {
         self.egl_context == egl::NO_CONTEXT
     }
 
-    unsafe fn destroy(&mut self, device: &Device) {
+    unsafe fn destroy(&mut self, _device: &Device) {
         assert!(!self.is_destroyed());
         self.egl_context = egl::NO_CONTEXT;
     }

--- a/surfman/src/platform/windows/angle/device.rs
+++ b/surfman/src/platform/windows/angle/device.rs
@@ -127,6 +127,10 @@ impl Device {
         Connection
     }
 
+    pub fn d3d11_device(&self) -> ComPtr<ID3D11Device> {
+        self.d3d11_device.clone()
+    }
+
     pub fn adapter(&self) -> Adapter {
         unsafe {
             let mut dxgi_device: *mut IDXGIDevice = ptr::null_mut();

--- a/surfman/src/platform/windows/angle/surface.rs
+++ b/surfman/src/platform/windows/angle/surface.rs
@@ -1,13 +1,13 @@
 //! Surface management for Direct3D 11 on Windows using the ANGLE library as a frontend.
 
 use crate::context::ContextID;
-use crate::egl::types::{EGLConfig, EGLSurface, EGLenum};
+use crate::egl::types::{EGLSurface, EGLenum};
 use crate::egl::{self, EGLint};
 use crate::gl::types::{GLenum, GLint, GLuint};
 use crate::gl;
 use crate::platform::generic::egl::error::ToWindowingApiError;
-use crate::{ContextAttributeFlags, Error, SurfaceAccess, SurfaceID, SurfaceType};
-use super::context::{self, Context, ContextDescriptor, GL_FUNCTIONS};
+use crate::{Error, SurfaceAccess, SurfaceID, SurfaceType};
+use super::context::{Context, ContextDescriptor, GL_FUNCTIONS};
 use super::device::{Device, EGL_EXTENSION_FUNCTIONS};
 
 use euclid::default::Size2D;
@@ -15,12 +15,10 @@ use std::fmt::{self, Debug, Formatter};
 use std::marker::PhantomData;
 use std::os::raw::c_void;
 use std::ptr;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use winapi::shared::dxgi::IDXGIKeyedMutex;
 use winapi::shared::windef::{HWND, RECT};
-use winapi::shared::winerror::{self, S_OK};
+use winapi::shared::winerror::S_OK;
 use winapi::um::d3d11;
 use winapi::um::handleapi::INVALID_HANDLE_VALUE;
 use winapi::um::winbase::INFINITE;
@@ -32,8 +30,6 @@ use wio::com::ComPtr;
 use winit::Window;
 #[cfg(feature = "sm-winit")]
 use winit::os::windows::WindowExt;
-
-const BYTES_PER_PIXEL: i32 = 4;
 
 const SURFACE_GL_TEXTURE_TARGET: GLenum = gl::TEXTURE_2D;
 
@@ -345,7 +341,7 @@ impl Device {
     }
 
     #[inline]
-    pub fn lock_surface_data<'s>(&self, surface: &'s mut Surface)
+    pub fn lock_surface_data<'s>(&self, _surface: &'s mut Surface)
                                  -> Result<SurfaceDataGuard<'s>, Error> {
         Err(Error::Unimplemented)
     }
@@ -401,9 +397,7 @@ impl NativeWidget {
     #[cfg(feature = "sm-winit")]
     #[inline]
     pub fn from_winit_window(window: &Window) -> NativeWidget {
-        unsafe {
-            NativeWidget { window_handle: window.get_hwnd() as HWND }
-        }
+        NativeWidget { window_handle: window.get_hwnd() as HWND }
     }
 }
 

--- a/surfman/src/platform/windows/wgl/surface.rs
+++ b/surfman/src/platform/windows/wgl/surface.rs
@@ -431,7 +431,7 @@ impl Device {
     }
 
     #[inline]
-    pub fn lock_surface_data<'s>(&self, surface: &'s mut Surface)
+    pub fn lock_surface_data<'s>(&self, _surface: &'s mut Surface)
                                  -> Result<SurfaceDataGuard<'s>, Error> {
         Err(Error::Unimplemented)
     }


### PR DESCRIPTION
Also includes some fixes that make it easier to blit between surfman-generated surfaces and ones with preexisting D3D textures.