### PR TITLE
Add mozangle/egl to dev-dependencies on windows

### DIFF
--- a/surfman/Cargo.toml
+++ b/surfman/Cargo.toml
@@ -80,6 +80,10 @@ version = "0.2"
 features = ["egl"]
 optional = true
 
+# Ensure that we have a static libEGL.lib present for running tests
+[target.'cfg(target_os = "windows")'.dev-dependencies]
+mozangle = { version = "0.2", features = ["egl"] }
+
 [target.'cfg(target_os = "windows")'.dependencies]
 wio = "0.2"
 winapi = { version = "0.3", features = ["d3d11", "wingdi", "winuser", "libloaderapi"] }


### PR DESCRIPTION
Add mozangle as a non-optional dev-dependency, which fixes link errors running unit tests in windows.