### PR TITLE
Create a real EGL surface when creating a surface from a texture.

### DIFF
--- a/surfman/src/platform/windows/angle/surface.rs
+++ b/surfman/src/platform/windows/angle/surface.rs
@@ -128,7 +128,16 @@ impl Device {
             ];
 
             EGL_FUNCTIONS.with(|egl| {
-                let egl_surface = if share_handle.is_some() {
+                let egl_surface = if let Some(HandleOrTexture::Texture(texture)) = share_handle {
+                    let surface =
+                        egl.CreatePbufferFromClientBuffer(self.native_display.egl_display(),
+                                                          EGL_D3D_TEXTURE_ANGLE,
+                                                          texture as *const _,
+                                                          egl_config,
+                                                          attributes.as_ptr());
+                    assert_ne!(surface, egl::NO_SURFACE);
+                    surface
+                } else if share_handle.is_some() {
                     egl::NO_SURFACE
                 } else {
                     let surface = egl.CreatePbufferSurface(self.native_display.egl_display(),


### PR DESCRIPTION
This applies to surfman 0.1.3. We need a solution for surfman 0.2.