### PR TITLE
Revert "Create a real EGL surface when creating a surface from a texture."

### DIFF
--- a/surfman/src/platform/windows/angle/surface.rs
+++ b/surfman/src/platform/windows/angle/surface.rs
@@ -158,16 +158,7 @@ impl Device {
             ];
 
             EGL_FUNCTIONS.with(|egl| {
-                let egl_surface = if let Some(HandleOrTexture::Texture(texture)) = share_handle {
-                    let surface =
-                        egl.CreatePbufferFromClientBuffer(self.native_display.egl_display(),
-                                                          EGL_D3D_TEXTURE_ANGLE,
-                                                          texture as *const _,
-                                                          egl_config,
-                                                          attributes.as_ptr());
-                    assert_ne!(surface, egl::NO_SURFACE);
-                    surface
-                } else if share_handle.is_some() {
+                let egl_surface = if share_handle.is_some() {
                     egl::NO_SURFACE
                 } else {
                     let surface = egl.CreatePbufferSurface(self.egl_display,


### PR DESCRIPTION
Reverts pcwalton/surfman#58. This does not actually compile when merged into the master branch.