### PR TITLE
Add Connection::create_native_widget_from_rwh()

### DIFF
--- a/surfman/Cargo.toml
+++ b/surfman/Cargo.toml
@@ -25,6 +25,7 @@ sm-test = []
 sm-wayland-default = []
 sm-winit = ["winit"]
 sm-x11 = ["x11"]
+sm-raw-window-handle = ["raw-window-handle"]
 
 [dependencies]
 bitflags = "1.1"
@@ -43,6 +44,10 @@ optional = true
 
 [dependencies.winit]
 version = "<0.19.4" # 0.19.4 causes build errors https://github.com/rust-windowing/winit/pull/1105
+optional = true
+
+[dependencies.raw-window-handle]
+version = "0.3.3"
 optional = true
 
 [dev-dependencies]
@@ -68,6 +73,7 @@ features = ["client", "dlopen", "egl"]
 [target.'cfg(all(unix, not(any(target_os = "macos", target_os = "android"))))'.dependencies.x11]
 version = "2.3.0"
 features = ["xlib"]
+optional = true
 
 [target.'cfg(any(not(unix), target_os = "macos", target_os = "android"))'.dependencies.x11]
 optional = true

--- a/surfman/Cargo.toml
+++ b/surfman/Cargo.toml
@@ -73,7 +73,6 @@ features = ["client", "dlopen", "egl"]
 [target.'cfg(all(unix, not(any(target_os = "macos", target_os = "android"))))'.dependencies.x11]
 version = "2.3.0"
 features = ["xlib"]
-optional = true
 
 [target.'cfg(any(not(unix), target_os = "macos", target_os = "android"))'.dependencies.x11]
 optional = true

--- a/surfman/src/connection.rs
+++ b/surfman/src/connection.rs
@@ -58,7 +58,7 @@ pub trait Connection: Sized {
     fn create_native_widget_from_winit_window(&self, window: &Window)
                                               -> Result<Self::NativeWidget, Error>;
 
-    /// Create a native widget type from the given `raw_window_handle::HasRawWindowHandle`.
+    /// Create a native widget type from the given `raw_window_handle::RawWindowHandle`.
     #[cfg(feature = "sm-raw-window-handle")]
     fn create_native_widget_from_rwh(&self, window: raw_window_handle::RawWindowHandle)
                                               -> Result<Self::NativeWidget, Error>;

--- a/surfman/src/connection.rs
+++ b/surfman/src/connection.rs
@@ -57,4 +57,9 @@ pub trait Connection: Sized {
     #[cfg(feature = "sm-winit")]
     fn create_native_widget_from_winit_window(&self, window: &Window)
                                               -> Result<Self::NativeWidget, Error>;
+
+    /// Create a native widget type from the given `raw_window_handle::HasRawWindowHandle`.
+    #[cfg(feature = "sm-raw-window-handle")]
+    fn create_native_widget_from_rwh(&self, window: raw_window_handle::RawWindowHandle)
+                                              -> Result<Self::NativeWidget, Error>;
 }

--- a/surfman/src/implementation/connection.rs
+++ b/surfman/src/implementation/connection.rs
@@ -72,4 +72,11 @@ impl ConnectionInterface for Connection {
                                               -> Result<NativeWidget, Error> {
         Connection::create_native_widget_from_winit_window(self, window)
     }
+
+    #[inline]
+    #[cfg(feature = "sm-raw-window-handle")]
+    fn create_native_widget_from_rwh(&self, window: raw_window_handle::RawWindowHandle)
+                                              -> Result<NativeWidget, Error> {
+        Connection::create_native_widget_from_rwh(self, window)
+    }
 }

--- a/surfman/src/platform/android/connection.rs
+++ b/surfman/src/platform/android/connection.rs
@@ -103,9 +103,16 @@ impl Connection {
     /// Create a native widget type from the given `raw_window_handle::RawWindowHandle`.
     #[cfg(feature = "sm-raw-window-handle")]
     #[inline]
-    pub fn create_native_widget_from_rwh(&self, _: raw_window_handle::RawWindowHandle)
-                                                  -> Result<NativeWidget, Error> {
-        Err(Error::UnsupportedOnThisPlatform)
+    pub fn create_native_widget_from_rwh(&self, raw_handle: raw_window_handle::RawWindowHandle)
+                                         -> Result<NativeWidget, Error> {
+        use raw_window_handle::RawWindowHandle::Android;
+
+        match raw_handle {
+            Android(handle) => Ok(NativeWidget {
+                native_ window: handle.a_native_window as *mut _,
+            }),
+            _ => Err(Error::IncompatibleNativeWidget),
+        }
     }
 }
 

--- a/surfman/src/platform/android/connection.rs
+++ b/surfman/src/platform/android/connection.rs
@@ -99,6 +99,14 @@ impl Connection {
                                                   -> Result<NativeWidget, Error> {
         Err(Error::UnsupportedOnThisPlatform)
     }
+
+    /// Create a native widget type from the given `raw_window_handle::RawWindowHandle`.
+    #[cfg(feature = "sm-raw-window-handle")]
+    #[inline]
+    pub fn create_native_widget_from_rwh(&self, _: raw_window_handle::RawWindowHandle)
+                                                  -> Result<NativeWidget, Error> {
+        Err(Error::UnsupportedOnThisPlatform)
+    }
 }
 
 impl NativeConnection {

--- a/surfman/src/platform/generic/multi/connection.rs
+++ b/surfman/src/platform/generic/multi/connection.rs
@@ -196,7 +196,7 @@ where
         }
     }
 
-    /// Create a native widget type from the given `raw_window_handle::HasRawWindowHandle`.
+    /// Create a native widget type from the given `raw_window_handle::RawWindowHandle`.
     #[cfg(feature = "sm-raw-window-handle")]
     pub fn create_native_widget_from_rwh(
         &self,

--- a/surfman/src/platform/macos/cgl/connection.rs
+++ b/surfman/src/platform/macos/cgl/connection.rs
@@ -11,6 +11,11 @@ use crate::platform::macos::system::device::NativeDevice;
 use crate::platform::macos::system::surface::NativeWidget;
 use super::device::{Adapter, Device};
 
+#[cfg(feature = "sm-raw-window-handle")]
+use crate::platform::macos::system::surface::NSView;
+#[cfg(feature = "sm-raw-window-handle")]
+use cocoa::base::id;
+
 #[cfg(feature = "sm-winit")]
 use winit::Window;
 
@@ -100,9 +105,17 @@ impl Connection {
     /// Create a native widget type from the given `raw_window_handle::RawWindowHandle`.
     #[cfg(feature = "sm-raw-window-handle")]
     #[inline]
-    pub fn create_native_widget_from_rwh(&self, _: raw_window_handle::RawWindowHandle)
-                                                  -> Result<NativeWidget, Error> {
-        // TODO: support raw window handle on cgl
-        Err(Error::UnsupportedOnThisPlatform)
+    pub fn create_native_widget_from_rwh(&self, raw_handle: raw_window_handle::RawWindowHandle)
+                                         -> Result<NativeWidget, Error> {
+        use raw_window_handle::RawWindowHandle::MacOS;
+
+        match raw_handle {
+            MacOS(handle) => Ok(NativeWidget {
+                view: NSView(unsafe {
+                    msg_send![handle.ns_view as id, retain]
+                }),
+            }),
+            _ => Err(Error::IncompatibleNativeWidget),
+        }
     }
 }

--- a/surfman/src/platform/macos/cgl/connection.rs
+++ b/surfman/src/platform/macos/cgl/connection.rs
@@ -96,4 +96,13 @@ impl Connection {
                                                   -> Result<NativeWidget, Error> {
         self.0.create_native_widget_from_winit_window(window)
     }
+
+    /// Create a native widget type from the given `raw_window_handle::RawWindowHandle`.
+    #[cfg(feature = "sm-raw-window-handle")]
+    #[inline]
+    pub fn create_native_widget_from_rwh(&self, _: raw_window_handle::RawWindowHandle)
+                                                  -> Result<NativeWidget, Error> {
+        // TODO: support raw window handle on cgl
+        Err(Error::UnsupportedOnThisPlatform)
+    }
 }

--- a/surfman/src/platform/macos/system/connection.rs
+++ b/surfman/src/platform/macos/system/connection.rs
@@ -138,10 +138,18 @@ impl Connection {
     /// Create a native widget type from the given `raw_window_handle::RawWindowHandle`.
     #[cfg(feature = "sm-raw-window-handle")]
     #[inline]
-    pub fn create_native_widget_from_rwh(&self, _: raw_window_handle::RawWindowHandle)
-                                                  -> Result<NativeWidget, Error> {
-        // TODO: support raw window handle on macos
-        Err(Error::UnsupportedOnThisPlatform)
+    pub fn create_native_widget_from_rwh(&self, raw_handle: raw_window_handle::RawWindowHandle)
+                                         -> Result<NativeWidget, Error> {
+        use raw_window_handle::RawWindowHandle::MacOS;
+
+        match raw_handle {
+            MacOS(handle) => Ok(NativeWidget {
+                view: NSView(unsafe {
+                    msg_send![handle.ns_view as id, retain]
+                }),
+            }),
+            _ => Err(Error::IncompatibleNativeWidget),
+        }
     }
 }
 

--- a/surfman/src/platform/macos/system/connection.rs
+++ b/surfman/src/platform/macos/system/connection.rs
@@ -134,6 +134,15 @@ impl Connection {
             Ok(NativeWidget { view: NSView(msg_send![ns_view, retain]) })
         }
     }
+
+    /// Create a native widget type from the given `raw_window_handle::RawWindowHandle`.
+    #[cfg(feature = "sm-raw-window-handle")]
+    #[inline]
+    pub fn create_native_widget_from_rwh(&self, _: raw_window_handle::RawWindowHandle)
+                                                  -> Result<NativeWidget, Error> {
+        // TODO: support raw window handle on macos
+        Err(Error::UnsupportedOnThisPlatform)
+    }
 }
 
 impl NativeConnection {

--- a/surfman/src/platform/unix/generic/connection.rs
+++ b/surfman/src/platform/unix/generic/connection.rs
@@ -139,5 +139,13 @@ impl Connection {
                                                   -> Result<NativeWidget, Error> {
         Err(Error::IncompatibleNativeWidget)
     }
+
+    /// Create a native widget type from the given `raw_window_handle::RawWindowHandle`.
+    #[cfg(feature = "sm-raw-window-handle")]
+    #[inline]
+    pub fn create_native_widget_from_rwh(&self, _: raw_window_handle::RawWindowHandle)
+                                                  -> Result<NativeWidget, Error> {
+        Err(Error::IncompatibleNativeWidget)
+    }
 }
 

--- a/surfman/src/platform/unix/mod.rs
+++ b/surfman/src/platform/unix/mod.rs
@@ -2,12 +2,18 @@
 //
 //! Backends specific to Unix-like systems, particularly Linux.
 
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "android"))))]
+// The default when x11 is enabled
+#[cfg(all(feature = "sm-x11", unix, not(any(target_os = "macos", target_os = "android"))))]
 pub mod default;
+
+// The default when x11 is not enabled
+#[cfg(not(all(feature = "sm-x11", unix, not(any(target_os = "macos", target_os = "android")))))]
+pub use wayland as default;
+
 #[cfg(all(unix, not(any(target_os = "macos", target_os = "android"))))]
 pub mod generic;
+
 #[cfg(all(unix, not(any(target_os = "macos", target_os = "android"))))]
 pub mod wayland;
-#[cfg(all(any(feature = "sm-x11",
-              all(unix, not(any(target_os = "macos", target_os = "android"))))))]
+#[cfg(all(feature = "sm-x11", unix, not(any(target_os = "macos", target_os = "android"))))]
 pub mod x11;

--- a/surfman/src/platform/unix/wayland/connection.rs
+++ b/surfman/src/platform/unix/wayland/connection.rs
@@ -174,7 +174,7 @@ impl Connection {
     }
 
     /// Creates a native widget type from the given `raw_window_handle::HasRawWindowHandle`
-    #[cfg(feature = "sm-winit")]
+    #[cfg(feature = "sm-raw-window-handle")]
     pub fn create_native_widget_from_rwh(
             &self,
             raw_handle: raw_window_handle::RawWindowHandle)

--- a/surfman/src/platform/unix/wayland/connection.rs
+++ b/surfman/src/platform/unix/wayland/connection.rs
@@ -172,6 +172,25 @@ impl Connection {
 
         Ok(NativeWidget { wayland_surface, size: window_size })
     }
+
+    /// Creates a native widget type from the given `raw_window_handle::HasRawWindowHandle`
+    #[cfg(feature = "sm-winit")]
+    pub fn create_native_widget_from_rwh(
+            &self,
+            raw_handle: raw_window_handle::RawWindowHandle)
+                                                  -> Result<NativeWidget, Error> {
+        use raw_window_handle::RawWindowHandle::Wayland;
+
+        let wayland_surface = match raw_handle {
+            Wayland(handle) => handle.surface as *mut wl_proxy,
+            _ => return Err(Error::IncompatibleNativeWidget),
+        };
+        
+        // TODO: Find out how to get actual size from the raw window handle
+        let window_size = Size2D::new(400, 500);
+
+        Ok(NativeWidget { wayland_surface, size: window_size })
+    }
 }
 
 impl Drop for NativeConnectionWrapper {

--- a/surfman/src/platform/windows/angle/connection.rs
+++ b/surfman/src/platform/windows/angle/connection.rs
@@ -125,6 +125,15 @@ impl Connection {
             Ok(NativeWidget { window_handle: hwnd })
         }
     }
+
+    /// Create a native widget type from the given `raw_window_handle::RawWindowHandle`.
+    #[cfg(feature = "sm-raw-window-handle")]
+    #[inline]
+    pub fn create_native_widget_from_rwh(&self, _: raw_window_handle::RawWindowHandle)
+                                                  -> Result<NativeWidget, Error> {
+        // TODO: support raw window handle on windows angle
+        Err(Error::UnsupportedOnThisPlatform)
+    }
 }
 
 impl NativeConnection {

--- a/surfman/src/platform/windows/wgl/connection.rs
+++ b/surfman/src/platform/windows/wgl/connection.rs
@@ -111,6 +111,15 @@ impl Connection {
             Ok(NativeWidget { window_handle: hwnd })
         }
     }
+
+    /// Create a native widget type from the given `raw_window_handle::RawWindowHandle`.
+    #[cfg(feature = "sm-raw-window-handle")]
+    #[inline]
+    pub fn create_native_widget_from_rwh(&self, _: raw_window_handle::RawWindowHandle)
+                                                  -> Result<NativeWidget, Error> {
+        // TODO: support raw window handle on wgl
+        Err(Error::UnsupportedOnThisPlatform)
+    }
 }
 
 impl NativeConnection {


### PR DESCRIPTION
Adds a function for creating a native widget from a raw window handle.

Not tested yet.

Fixes #60.