### PR TITLE
Update Threads Example to Use GLVersion 3.3

### DIFF
--- a/surfman/examples/threads.rs
+++ b/surfman/examples/threads.rs
@@ -101,7 +101,7 @@ fn main() {
     let mut device = connection.create_device(&adapter).unwrap();
 
     let context_attributes = ContextAttributes {
-        version: GLVersion::new(3, 0),
+        version: GLVersion::new(3, 3),
         flags: ContextAttributeFlags::ALPHA,
     };
     let context_descriptor = device.create_context_descriptor(&context_attributes).unwrap();


### PR DESCRIPTION
I was testing the threads example and I had to update the GLVersion to 3.3 for the shader to compile.